### PR TITLE
When upgrading mobile to Angular4

### DIFF
--- a/src/app/malihu-scrollbar/malihu-scrollbar.service.ts
+++ b/src/app/malihu-scrollbar/malihu-scrollbar.service.ts
@@ -35,7 +35,7 @@ export class MalihuScrollbarService {
     if (typeof element === 'string' || element instanceof String) {
       return $(element);
     }
-    if ((typeof element === 'object' || element instanceof Object) && element instanceof HTMLElement) {
+    if (typeof element === 'object' && element instanceof HTMLElement) {
       return $(element);
     }
     if (element instanceof jQuery || 'jquery' in Object(element)) {


### PR DESCRIPTION
I get an error:

The left-hand side of an 'instanceof' expression must be of type 'any'.

tracking main fork removed that line in [later commit](https://github.com/jfcere/ngx-malihu-scrollbar/commit/281727d867e055aea99ce9740ab887622f23111d)

Error goes away after removal.